### PR TITLE
Update README.md for onLogin script to fix 0 validity issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Put on the on login script (with telegram support) please change accordinly with
 :local URLvendoID 5;
 
 # Get User Data
-:local aUsrNote [/ip hotspot user get $user comment];
-:local aUsrNote [:toarray $aUsrNote];
+:local iUsrNote [/ip hotspot user get $user comment];
+:local aUsrNote [:toarray $iUsrNote];
 :local iUsrTime [:totime ($aUsrNote->0)];
 :local iSaleAmt [:tonum ($aUsrNote->1)];
 :local iExtCode ($aUsrNote->2);
@@ -225,13 +225,17 @@ Put on the on login script (with telegram support) please change accordinly with
 # Extend User
   :if (($iUserReg!="") and ($iExtCode=1)) do={
     :local iTimeInt [/system scheduler get $user interval];
-    /system scheduler set $user interval=( $iTimeInt + $iUsrTime );
+    :set iTimeInt ( $iTimeInt + $iUsrTime )
+    :if ($iTimeInt<$iTimeMin) do={ :set iTimeInt ($iTimeMin+$iUsrTime); }
+    /system scheduler set $user interval=$iTimeInt;
   }
 # ADD User
   :local iDateBeg [/system clock get date];
   :local iTimeBeg [/system clock get time];
   :if ($iUserReg="") do={
-    :do { /system scheduler add name="$user" interval=$iUsrTime \
+    :local iTimeInt $iUsrTime;
+    :if ($iUsrTime<$iTimeMin) do={ :set iTimeInt ($iTimeMin+$iUsrTime); };
+    :do { /system scheduler add name="$user" interval=$iTimeInt \
       start-date=$iDateBeg start-time=$iTimeBeg disable=no \
       policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon \
       on-event=("/ip hotspot user remove [find name=$user];\r\n".\
@@ -293,6 +297,7 @@ Put on the on login script (with telegram support) please change accordinly with
     :if ($cmac!=$amac) do={  /ip hotspot active remove [/ip hotspot active find mac-address="$amac"]; }
   }
 }
+
 ```
 Put on the on logout script
 ```bash


### PR DESCRIPTION
We found some issues with validity.
1. if validity = 0.
2. if validity > user-limit-uptime.
both the #add-user and #extend-user are affected.
Solution:
- on #add-user
    :if ($iUsrTime<$iTimeMin) do={ :set iTimeInt ($iTimeMin+$iUsrTime); };
- on #extend-user
    :if ($iTimeInt<$iTimeMin) do={ :set iTimeInt ($iTimeMin+$iUsrTime); }
